### PR TITLE
Reworked and fixed and security improved version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,11 @@
     id: "{{ koha_signing_key_id }}"
   when: koha_signing_key_id is defined and koha_signing_key_id|length > 0
 
+- name: Add primary repository signing key by content
+  apt_key:
+    data: "{{ koha_signing_key_content }}"
+  when: koha_signing_key_content is defined and koha_signing_key_content|length > 0
+
 - name: Add primary repository
   apt_repository:
     repo: "{{ koha_package_repository }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,7 @@
   lineinfile:
     path: /etc/hosts
     line: "127.0.1.1 {{ koha_domain }}"
+    insertafter: '127\.0\.0\.1 localhost'
     state: present
 
 - name: Enable required Apache modules

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,16 @@
   timezone:
     name: "{{ koha_server_timezone }}"
 
+- name: Check to have {{ koha_domain }} domain in /etc/hosts
+  become: yes
+  lineinfile:
+    path: /etc/hosts
+    line: "127.0.1.1 {{ koha_domain }}"
+    insertafter: '127\.0\.0\.1 localhost'
+    state: present
+
+
+
 - name: Add Koha package repository signing key
   apt_key:
     keyserver: "{{ koha_keyserver }}"
@@ -20,14 +30,6 @@
   loop:
     - koha-common
     - koha-elasticsearch
-
-- name: Check to have {{ koha_domain }} domain in /etc/hosts
-  become: yes
-  lineinfile:
-    path: /etc/hosts
-    line: "127.0.1.1 {{ koha_domain }}"
-    insertafter: '127\.0\.0\.1 localhost'
-    state: present
 
 - name: Enable required Apache modules
   apache2_module:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,11 +18,11 @@
     id: "{{ koha_signing_key_id }}"
   when: koha_signing_key_id is defined and koha_signing_key_id|length > 0
 
-- name: Add Koha package repository
+- name: Add primary repository
   apt_repository:
     repo: "{{ koha_package_repository }}"
     state: present
-    filename: koha-packages
+    filename: koha-primary
 
 - name: Install Koha packages
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,11 @@
 
 
 
-- name: Add Koha package repository signing key
+- name: Add primary repository signing key
   apt_key:
     keyserver: "{{ koha_keyserver }}"
     id: "{{ koha_signing_key_id }}"
+  when: koha_signing_key_id is defined and koha_signing_key_id|length > 0
 
 - name: Add Koha package repository
   apt_repository:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,25 @@
     state: present
     filename: koha-primary
 
+- name: Add secondary package repository signing key
+  apt_key:
+    keyserver: "{{ koha_secondary_keyserver }}"
+    id: "{{ koha_secondary_signing_key_id }}"
+  when: 
+   - koha_secondary_signing_key_id is defined and koha_secondary_signing_key_id|length > 0
+   - koha_secondary_keyserver is defined and koha_secondary_keyserver|length > 0
+
+- name: Add secondary repository signing key by content
+  apt_key:
+    data: "{{ koha_secondary_signing_key_content }}"
+  when: koha_secondary_signing_key_content is defined and koha_secondary_signing_key_content|length > 0
+
+- name: Add secondary repository
+  apt_repository:
+    repo: "{{ koha_secondary_package_repository }}"
+    state: present
+    filename: koha-secondary
+
 - name: Install Koha packages
   package:
     name: "{{ item }}"
@@ -36,6 +55,8 @@
   loop:
     - koha-common
     - koha-elasticsearch
+
+
 
 - name: Enable required Apache modules
   apache2_module:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,15 @@
     state: present
     filename: koha-secondary
 
+- name: Configure pinning for koha-common
+  template:
+    src: pin-koha.j2
+    dest: /etc/apt/preferences.d/koha
+    owner: root
+    group: root
+    mode: u=rw,g=r
+  when: koha_secondary_package_rep_domain is defined and koha_secondary_package_rep_domain|length > 0
+
 - name: Install Koha packages
   package:
     name: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,4 +130,4 @@
     MEMCACHED_NAMESPACE: '{{ koha_memcached_ns_prefix }}{{ koha_instance_name }}'
   register: koha_languages_install
   failed_when: koha_languages_install.stderr != ''
-  when: item not in koha_installed_languages.stdout
+  when: koha_installed_languages is defined and item not in koha_installed_languages.stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,9 +43,11 @@
     - ssl
   register: apache_modules
 
+
+
 - name: Assign 'koha user exists' test variable
   set_fact: koha_user_exists_error_message="User {{ koha_instance_name }}-koha already exists"
-  when: koha_create_instance|bool
+  when: koha_create_instance | bool
 
 - name: Create Koha instance
   command: koha-create {{ koha_instance_name }} --use-db --database {{ koha_db_database }}
@@ -54,7 +56,7 @@
     - koha_create_result.rc != 0
     - 'koha_user_exists_error_message not in koha_create_result.stderr'
   changed_when: "koha_user_exists_error_message not in koha_create_result.stderr"
-  when: koha_create_instance|bool
+  when: koha_create_instance | bool
 
 - name: Configure koha-conf.xml
   template:
@@ -72,6 +74,8 @@
     - koha_plack_result.rc != 0
     - '"Plack already enabled for" not in koha_plack_result.stderr'
   changed_when: '"Plack already enabled for" not in koha_plack_result.stderr'
+
+
 
 - name: Configure apache2
   template:
@@ -98,6 +102,8 @@
   changed_when: '"SIP server already enabled" not in koha_sip_result.stdout'
   when: koha_sip_enable
 
+
+
 - name: Restart koha-common
   systemd:
     state: restarted
@@ -115,6 +121,8 @@
     name: apache2
     state: restarted
   when: apache_modules.changed or koha_plack_result.changed or apache_conf.changed
+
+
 
 - name: Check for installed translations
   command: "koha-translate --list"

--- a/templates/pin-koha.j2
+++ b/templates/pin-koha.j2
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin {{ koha_secondary_package_rep_domain }}
+Pin-Priority: 990


### PR DESCRIPTION
Story:
- Prevent for undef error with language list in a case if not yet any language installed (koha_installed_languages is defined)
- Add place where to put domain in hosts (insertafter)
- Move server-related configs to be grouped
- White space: blocks visually grouped
- Add main repository only if key defined (koha_signing_key_id)
- Make main repository named "koha-community"
- Add feature to add key by content (koha_signing_key_content)
- Add feature to have secondary koha repository
- Feature for future re-use to install one custom built koha-common over general koha-common with dependencies. Vars:
koha_extra_keyserver, koha_extra_signing_key_id, koha_extra_signing_key_content, koha_extra_package_repository 
- Add pinning for secondary repo and koha_extra_package_rep_domain variable
- Add sshd hardening
- Add Apache security hardening
