### PR TITLE
Remove deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,7 @@
     owner: root
     group: root
     mode: u=rw,g=r
-  when: koha_custom_daily_crons
+  when: koha_custom_daily_crons | bool
 
 - name: Install Koha packages
   package:


### PR DESCRIPTION
[DEPRECATION WARNING]: evaluating 'koha_custom_daily_crons' as a bare variable, this behaviour will go away and you
might need to add |bool to the expression in the future.