### PR TITLE
Skip secondary repository if not defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     repo: "{{ koha_secondary_package_repository }}"
     state: present
     filename: koha-secondary
+  when: koha_secondary_package_repository is defined and koha_secondary_package_repository|length > 0
 
 - name: Configure pinning for koha-common
   template:


### PR DESCRIPTION
This pull request aims to add checks to ensure secondary package repository is defined before attempting to add it.

Otherwise, a default execution will end with a following error:

```
The task includes an option with an undefined variable. The error was: 'koha_secondary_package_repository' is undefined

The error appears to be in '/home/ansible/KKKAnsible/roles/ansible-role-koha/tasks/main.yml': line 45, column 3
```